### PR TITLE
starting on the data view

### DIFF
--- a/src/Components/Form/Form.tsx
+++ b/src/Components/Form/Form.tsx
@@ -1,18 +1,21 @@
-import React, {useEffect, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import StyledTextInput from './StyledTextInput';
 import StyledButton from './StyledButton';
 import postcodeValidator from '../../utils/postcodeValidator';
 import fetchData from '../../utils/fetchData';
-import { crimeDataTypes } from '../../utils/types/crimeDataTypes';
 import { locationDetailsTypes } from '../../utils/types/locationTypes';
 import crimeLinkConstructor from '../../utils/crimeLinkConstructor';
 import { errorMessages } from '../../utils/error';
 
-function Form () {
-    const [data, setData] = useState<crimeDataTypes[] | []>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+import { Data } from '../../utils/context/DataContext';
+import { Loading } from '../../utils/context/LoadingContext';
+import { Error } from '../../utils/context/ErrorContext';
 
+function Form () {
+
+    const { data, setData } = useContext(Data);
+    const { setLoading } = useContext(Loading);
+    const { setError } = useContext(Error);
 
     const [postCode, setPostCode] = useState<string>("");
 
@@ -25,11 +28,9 @@ function Form () {
         }
     }, [win]);
 
-
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setPostCode(e.target.value);
     };
-
 
     const handleSubmit = async (e: React.MouseEvent) => {
         e.preventDefault();
@@ -43,7 +44,6 @@ function Form () {
                         latitude: locationData.data.latitude,
                         longitude: locationData.data.longitude,
                     };
-
                     win.setItem('postcode', postCode);
                     const crimeLink = crimeLinkConstructor(locationDetails);
                     const crimeData = await fetchData(crimeLink);
@@ -55,10 +55,14 @@ function Form () {
                 }
         } else {
             setError(errorMessages.INVALID_POSTCODE);
+            setLoading(false);
         }
     };
 
-    console.log('data: ', data, 'loading: ', loading, 'error: ', error);
+    console.log(data);
+
+    // TODO: When the button is clicked it should show the data view with
+    // an option to go to Map view (currently doesn't exist)
 
     return (
         <form>

--- a/src/Components/LoadingText/Loading.tsx
+++ b/src/Components/LoadingText/Loading.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import StyledLoading from './StyledLoading.styled';
+
+function LoadingText () {
+    return <StyledLoading>
+        Loading...
+    </StyledLoading>;
+}
+
+export default LoadingText;

--- a/src/Components/LoadingText/StyledLoading.styled.ts
+++ b/src/Components/LoadingText/StyledLoading.styled.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+const StyledLoading = styled.div`
+    height: 100px;
+`;
+
+export default StyledLoading;

--- a/src/Components/StyledDiv.styled.ts
+++ b/src/Components/StyledDiv.styled.ts
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 
-const StyledDiv = styled.div<{height?: string}>`
+const StyledDiv = styled.div<{height?: string, align?: string}>`
     width: 100%;
     position: relative;
-    text-align: center;
+    text-align: ${(props) => props.align ? props.align : "left"};
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
+    align-items: ${(props) => props.align ? props.align : "left"};
+    justify-content: ${(props) => props.align ? props.align : "left"};
     height: ${(props) => props.height ? props.height : "auto"};
 `;
 

--- a/src/Components/StyledUl.styled.ts
+++ b/src/Components/StyledUl.styled.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const StyledUl = styled.ul`
+    margin-left: 20px;
+    margin-bottom: 40px;
+`;
+
+
+export const StyledLi = styled.li`
+    list
+`;

--- a/src/Components/StyledView.styled.ts
+++ b/src/Components/StyledView.styled.ts
@@ -2,8 +2,7 @@ import styled from "styled-components";
 import StyledDiv from "./StyledDiv.styled";
 
 const StyledView = styled(StyledDiv)<{height?: string}>`
-    height: 300px;
-    border: 1px solid red;
+    padding: 10px;
 `;
 
 export default StyledView;

--- a/src/Components/Table/StyledTable.styled.ts
+++ b/src/Components/Table/StyledTable.styled.ts
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const StyledTable = styled.table`
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 56px;
+`;
+
+export const StyledTd = styled.td`
+    padding: 8px;
+    text-align: left;    
+`;
+
+export const StyledThead = styled.thead`
+    background-color: #CAF4A9;
+`;

--- a/src/Routes/DataView.tsx
+++ b/src/Routes/DataView.tsx
@@ -1,12 +1,92 @@
-import React from 'react';
+import React, {useContext} from 'react';
+import { Data } from '../utils/context/DataContext';
 import StyledView from '../Components/StyledView.styled';
+import {
+    StyledTable, 
+    StyledTd, 
+    StyledThead
+} from '../Components/Table/StyledTable.styled';
+import StyledDiv from '../Components/StyledDiv.styled';
+import { StyledLi, StyledUl } from '../Components/StyledUl.styled';
+import { DataType } from '../utils/types/dataTypes';
+import { Loading } from '../utils/context/LoadingContext';
+import LoadingText from '../Components/LoadingText/Loading';
+import { Error } from '../utils/context/ErrorContext';
 
 function DataView () {
-    return (
-        <StyledView height="90vh">
-            Data View
-        </StyledView>
-    );
+
+    const { data } = useContext(Data);
+    const { loading } = useContext(Loading);
+    const { error } = useContext(Error);
+
+    const postCode = "postcode"; // TODO: This should be brought over
+    // into the data context, currently is hardcoded so it doesn't break
+
+    const capitalise = (word: string) => 
+        word.charAt(0).toUpperCase() + word.slice(1);
+        
+    return loading ? <StyledDiv align="center"><LoadingText /></StyledDiv> : 
+                (error 
+                    ? <StyledDiv align="center"><p>{error}</p></StyledDiv> 
+                    : data.length 
+                        ?   
+                    (<StyledView>
+                        <p>Navigate to a crime type:</p>
+                        {/* TODO: turn these into anchor links */}
+                        <StyledUl>
+                            {data.map((crimeType: DataType, i:number)=> 
+                                <StyledLi key={i}>
+                                    {capitalise(crimeType.category)}
+                                </StyledLi>
+                            )} 
+                        </StyledUl>
+
+                        {data.map((crimeType: DataType, i: number)=>
+                            <StyledDiv key={i}>
+                                <h2>{capitalise(crimeType.category)}</h2>
+                                <StyledTable>
+                                <StyledThead>
+                                    <tr>
+                                        <StyledTd>
+                                            Date
+                                        </StyledTd>
+                                        <StyledTd>
+                                            Street Name
+                                        </StyledTd>
+                                        <StyledTd>
+                                            Postcode
+                                        </StyledTd>
+                                        <StyledTd>
+                                            Outcome status
+                                        </StyledTd>
+                                    </tr>
+                                </StyledThead>
+                                <tbody>
+                                    <tr>
+                                        <StyledTd>
+                                            {crimeType.outcome_status.date}
+                                        </StyledTd>
+                                        <StyledTd>
+                                            {crimeType.location.street.name}
+                                        </StyledTd>
+                                        <StyledTd>
+                                            {postCode}
+                                        </StyledTd>
+                                        <StyledTd>
+                                            {crimeType.outcome_status.category ?
+                                              crimeType.outcome_status.category
+                                                : "On Going"}
+                                        </StyledTd>
+                                    </tr>
+                                </tbody>
+                                </StyledTable>
+                            </StyledDiv>
+                        )}
+                    </StyledView>) : (
+                        <StyledDiv align="center" height="100px">
+                            <p>No data to show</p>
+                        </StyledDiv>)
+    );        
 }
 
 export default DataView;

--- a/src/Routes/pageLayout.tsx
+++ b/src/Routes/pageLayout.tsx
@@ -2,23 +2,30 @@ import React from 'react';
 import { Link, Outlet } from 'react-router-dom';
 import StyledDiv from '../Components/StyledDiv.styled';
 import Form from '../Components/Form/Form';
+import { DataContext } from '../utils/context/DataContext';
+import { LoadingContext } from '../utils/context/LoadingContext';
+import { ErrorContext } from '../utils/context/ErrorContext';
 
 function PageLayout () {
     return (
         <StyledDiv>
-            <StyledDiv>
+            <StyledDiv align="center">
                 <h1>SchemeServe Technical Test</h1>
             </StyledDiv>
+            
+            <DataContext>
+                <LoadingContext>
+                    <ErrorContext>
+                        <StyledDiv align="center">
+                            <Form />
+                        </StyledDiv>
+                        
+                        <Outlet />
+                    </ErrorContext>
+                </ LoadingContext>
+            </DataContext>
 
-            <StyledDiv>
-                <Form />
-            </StyledDiv>
-
-            <StyledDiv>
-                <Outlet />
-            </StyledDiv>
-
-            <StyledDiv>
+            <StyledDiv align="center">
                 Created by 
                     <Link 
                         to="http://github.com/piperbates" 

--- a/src/globalStyles.ts
+++ b/src/globalStyles.ts
@@ -16,7 +16,15 @@ const GlobalStyle = createGlobalStyle`
     }
 
     h1 {
+        margin-top: 16px;
         margin-bottom: 28px;
+        font-size: 2em;
+    }
+
+    h2 {
+        margin-bottom: 20px;
+        font-size: 1.5em;
+        font-weight: 500;
     }
 
     p {

--- a/src/utils/context/DataContext.tsx
+++ b/src/utils/context/DataContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useState, SetStateAction, Dispatch } from "react";
+import { DataType } from "../types/dataTypes";
+
+type DataPropTypes = {
+    children: React.ReactNode
+};
+
+type DataContextTypes = {
+    data: DataType[] | [],
+    setData: Dispatch<SetStateAction<
+        DataType[] | []>>,
+    };
+
+export const Data = createContext<DataContextTypes>({
+    data: [],
+    setData: () => {},
+});
+
+export function DataContext ({children}: DataPropTypes) {
+    const [data, setData] = useState<DataType[] | []>([]);
+
+    return (
+        <Data.Provider value={{ data, setData,}}>
+          {children}
+        </Data.Provider>
+      );
+};

--- a/src/utils/context/ErrorContext.tsx
+++ b/src/utils/context/ErrorContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useState, SetStateAction, Dispatch } from "react";
+
+type ErrorPropTypes = {
+    children: React.ReactNode
+};
+
+type ErrorContextTypes = {
+    error: string | null,
+    setError: Dispatch<SetStateAction<string | null>>,
+};
+
+export const Error = createContext<ErrorContextTypes>({
+    error: null,
+    setError: () => {},
+});
+
+export function ErrorContext ({children}: ErrorPropTypes) {
+    const [error, setError] = useState<string | null>(null);
+
+    return (
+        <Error.Provider value={{ error, setError,}}>
+          {children}
+        </Error.Provider>
+      );
+};

--- a/src/utils/context/LoadingContext.tsx
+++ b/src/utils/context/LoadingContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useState, SetStateAction, Dispatch } from "react";
+
+type LoadingPropTypes = {
+    children: React.ReactNode
+};
+
+type LoadingContextTypes = {
+    loading: boolean,
+    setLoading: Dispatch<SetStateAction<boolean>>,
+    };
+
+export const Loading = createContext<LoadingContextTypes>({
+    loading: false,
+    setLoading: () => {},
+});
+
+export function LoadingContext ({children}: LoadingPropTypes) {
+    const [loading, setLoading] = useState<boolean>(false);
+
+    return (
+        <Loading.Provider value={{ loading, setLoading,}}>
+          {children}
+        </Loading.Provider>
+      );
+};

--- a/src/utils/crimeLinkConstructor.ts
+++ b/src/utils/crimeLinkConstructor.ts
@@ -1,8 +1,12 @@
 import { locationDetailsTypes } from "./types/locationTypes";
 
 function crimeLinkConstructor (location: locationDetailsTypes ) {
+    // TODO: There's an issue with this link, it's returning an empty array.
+    // I've temporarily hardcoded a date in it because that needs to be there,
+    // and when the bug is fixed I can get a variable date in.
+
     //eslint-disable-next-line
-    return `https://data.police.uk/api/crimes-at-location?lat=${location.latitude}&lng=${location.longitude}`;
+    return `https://data.police.uk/api/crimes-at-location?date=2022-02&lat=${location.latitude}&lng=${location.longitude}`;
 }
 
 export default crimeLinkConstructor;

--- a/src/utils/types/dataTypes.ts
+++ b/src/utils/types/dataTypes.ts
@@ -1,0 +1,11 @@
+export type DataType = {
+    "category": string,
+    location:
+    {"street": {
+        "name": string,
+    },}
+    "outcome_status": {
+        "category": string | null,
+        "date": string,
+    },
+}


### PR DESCRIPTION
Added:
- Context to handle the data being pulled through to all relevant components as well as a loading and error contexts
- A basic loading component so something would show while the api call is being run
- Made a basic table for the Data view

Bugs:
There is a bug when generating the crime api link, it currently does not produce a valid api link and so returns no data, although the API does return a status 200. 

Todos:
- Bring the postcode into the data context, it's currently hardcoded in data view component
- When searching on the / route it should go to the data route with an option to go through to map route (which currently doesn't exist)
- The postcode search is in an MVP state where it's just accepting one postcode, needs to be implemented to allow multiple postcodes seperated by comma,
- If the page is loaded with postcodes within the query string it should trigger a search on those postcodes
- Historic search implementation
- Map view implementation
- Correct some typing
- Make it look pretty!